### PR TITLE
Update 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,40 @@ public class Main {
 	private Main instance;
 	private Logger logger;
 	private static LocaleService localeService;
-	public LocaleService getLocaleAPI() {
+	public LocaleService getLocaleService() {
 		return localeService;
 	}
 
+	// Get API. Variant 1. This happens in event `ConstructPluginEvent`.  It's recommended if LocaleAPI is mandatory.
 	@Listener
-	public void onEnable(StartedEngineEvent<Server> event) {
+	public void onLocaleServisePostEvent(LocaleServiseEvent.Construct event) {
 		instance = this;
-		// Apache logger
 		logger = LogManager.getLogger("PluginName");
-		// Get API
-		if(Sponge.pluginManager().plugin("localeapi").isPresent() && Sponge.pluginManager().isLoaded("localeapi")) {
-			localeService = ((LocaleAPIMain) Sponge.pluginManager().plugin("localeapi").get().instance()).getAPI();
-		}
+		localeService = event.getLocaleService();
+		testLocales();
+	}
+
+	// Get API. Variant 2. This happens in event `StartedEngineEvent<Server>`. It's recommended if LocaleAPI is optional.
+	// Recommended if LocaleAPI is optional. In this case, you can specify another class as the event listener.
+	@Listener
+	public void onLocaleServisePostEvent(LocaleServiseEvent.Started event) {
+		localeService = event.getLocaleService();
+		testLocales();
+	}
+
+	public void testLocales() {
 		if(!localeService.localesExist(instance)) {
 			localeService.createPluginLocale(instance, ConfigTypes.HOCON, Locales.DEFAULT);
-			//		       ^^ Main class or "pluginid".
+			//		                          ^^ Main class or "pluginid".
 			localeService.createPluginLocale(instance, ConfigTypes.HOCON, Locales.DEFAULT);
 			getLocaleUtil(Locales.DEFAULT).checkString("Your string for localization.", "Optional comment", "Path");
 		}
-		
 		// Get message from locale. You can get and use the player's localization 'player.locale();'.
+		// The boolean parameter defines what type of string serializer will be used.
 		logger.info(getLocaleUtil(Locales.DEFAULT).getComponent(false, "Path"));
 	}
 
-	public LocaleUtil getLocaleUtil(Locale locale) {
+	public AbstractLocaleUtil getLocaleUtil(Locale locale) {
 		return localeService.getOrDefaultLocale(instance, locale);
 	}
 }
@@ -41,15 +50,15 @@ public class Main {
 ##### Gradle
 ```gradle
 repositories {
-    ...
-    maven { 
-        name = "JitPack"
-        url 'https://jitpack.io' 
-    }
+	...
+	maven { 
+		name = "JitPack"
+		url 'https://jitpack.io' 
+	}
 }
 dependencies {
-    ...
-    implementation 'com.github.SawFowl:LocaleAPI:API8-SNAPSHOT'
+	...
+	implementation 'com.github.SawFowl:LocaleAPI:API8-SNAPSHOT'
 }
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ group = "sawfowl.localeapi"
 version = "${major}.${minor}.${patch}-${api}-${suffix}"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 ## Version
 major=2
-minor=0
+minor=1
 patch=0
-api=S8.0.0-SNAPSHOT
+api=S8.0.0
 suffix=RELEASE
 ## Dependencies
-spongeapi=8.0.0-SNAPSHOT
+spongeapi=8.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/sawfowl/localeapi/LocaleAPIMain.java
+++ b/src/main/java/sawfowl/localeapi/LocaleAPIMain.java
@@ -1,6 +1,6 @@
 /*
  * LocaleAPI - Locale API for Sponge plugins.
- * Copyright (C) 2019 - 2021 Mr_Krab
+ * Copyright (C) 2019 - 2022 SawFowl
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,15 +14,19 @@
  */
 package sawfowl.localeapi;
 
-import java.io.File;
 import java.nio.file.Path;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.spongepowered.api.Server;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.config.ConfigDir;
-import org.spongepowered.configurate.ConfigurationOptions;
-import org.spongepowered.configurate.objectmapping.ObjectMapper;
-import org.spongepowered.configurate.objectmapping.meta.NodeResolver;
-import org.spongepowered.configurate.serialize.TypeSerializerCollection;
+import org.spongepowered.api.event.Cause;
+import org.spongepowered.api.event.EventContext;
+import org.spongepowered.api.event.EventContextKeys;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.impl.AbstractEvent;
+import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.api.event.lifecycle.StartedEngineEvent;
 import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.builtin.jvm.Plugin;
 
@@ -30,56 +34,62 @@ import com.google.inject.Inject;
 
 import sawfowl.localeapi.api.LocaleAPI;
 import sawfowl.localeapi.api.LocaleService;
+import sawfowl.localeapi.event.LocaleServiseEvent;
 
 @Plugin("localeapi")
 public class LocaleAPIMain {
 
-	private Path configDir;
-	private File configFile;
 	private Logger logger;
-
-	private PluginContainer pluginContainer;
-	private LocaleAPIMain instance;
-	private LocaleService api;
-	private ObjectMapper.Factory factory;
-	private TypeSerializerCollection child;
-	private ConfigurationOptions options;
+	private LocaleService localeService;
+	private Cause cause;
 
 	@Inject
 	public LocaleAPIMain(PluginContainer pluginContainer, @ConfigDir(sharedRoot = false) Path configDirectory) {
-		this.configDir = configDirectory;
-		this.pluginContainer = pluginContainer;
-		instance = this;
 		logger = LogManager.getLogger("LocaleAPI");
-		this.configFile = configDir.toFile();
-		factory = ObjectMapper.factoryBuilder().addNodeResolver(NodeResolver.onlyWithSetting()).build();
-		child = TypeSerializerCollection.defaults().childBuilder().registerAnnotatedObjects(factory).build();
-		options = ConfigurationOptions.defaults().serializers(child);
-		api = new LocaleAPI(instance);
+		localeService = new LocaleAPI(logger, configDirectory);
+		cause = Cause.of(EventContext.builder().add(EventContextKeys.PLUGIN, pluginContainer).build(), pluginContainer);
 	}
 
-	public Logger getLogger() {
-		return logger;
+	@Listener
+	public void onConstruct(ConstructPluginEvent event) {
+		class ConstructEvent extends AbstractEvent implements LocaleServiseEvent.Construct {
+			@Override
+			public Cause cause() {
+				return cause;
+			}
+			@Override
+			public LocaleService getLocaleService() {
+				return localeService;
+			}
+		}
+		LocaleServiseEvent.Construct constructEvent = new ConstructEvent();
+		Sponge.eventManager().post(constructEvent);
 	}
 
-	public File getConfigFile() {
-		return configFile;
+	@Listener
+	public void onStarted(StartedEngineEvent<Server> event) {
+		class StartedEvent extends AbstractEvent implements LocaleServiseEvent.Started {
+			@Override
+			public Cause cause() {
+				return cause;
+			}
+			@Override
+			public LocaleService getLocaleService() {
+				return localeService;
+			}
+		}
+		LocaleServiseEvent.Started startedEvent = new StartedEvent();
+		Sponge.eventManager().post(startedEvent);
 	}
 
-	public Path getConfigDir() {
-		return configDir;
-	}
-
+	/**
+	 * This method is deprecated and will be removed in the future. </br>
+	 * To get the plugin API, you need to implement the `EventForGetLocaleServise` interface. </br>
+	 * See documentation.
+	 */
+	@Deprecated
 	public LocaleService getAPI() {
-		return api;
-	}
-
-	public PluginContainer getPluginContainer() {
-		return pluginContainer;
-	}
-
-	public ConfigurationOptions getConfigurationOptions() {
-		return options;
+		return localeService;
 	}
 
 }

--- a/src/main/java/sawfowl/localeapi/api/ConfigTypes.java
+++ b/src/main/java/sawfowl/localeapi/api/ConfigTypes.java
@@ -2,9 +2,31 @@ package sawfowl.localeapi.api;
 
 public enum ConfigTypes {
 
-	HOCON,
-	JSON,
-	YAML,
-	PROPERTIES
+	HOCON(".conf") {
+        @Override
+        public String toString() {
+            return ".conf";
+        }
+    },
+	JSON(".json") {
+        @Override
+        public String toString() {
+            return ".json";
+        }
+    },
+	YAML(".yml") {
+        @Override
+        public String toString() {
+            return ".yml";
+        }
+    },
+	PROPERTIES(".properties") {
+        @Override
+        public String toString() {
+            return ".properties";
+        }
+    };
+
+	ConfigTypes(String string) {}
 
 }

--- a/src/main/java/sawfowl/localeapi/api/LocaleService.java
+++ b/src/main/java/sawfowl/localeapi/api/LocaleService.java
@@ -66,17 +66,15 @@ public interface LocaleService {
 	 * Save plugin locales from assets.
 	 * 
 	 * @param plugin - A class annotated with '@Plugin'.
-	 * @param configType - Selected config type. See enum class 'ConfigTypes'.
 	 */
-	public void saveAssetLocales(Object plugin, ConfigTypes configType);
+	public void saveAssetLocales(Object plugin);
 
 	/**
 	 * Save plugin locales from assets.
 	 * 
 	 * @param pluginID - Plugin ID.
-	 * @param configType - Selected config type. See enum class 'ConfigTypes'.
 	 */
-	public void saveAssetLocales(String pluginID, ConfigTypes configType);
+	public void saveAssetLocales(String pluginID);
 
 	/**
 	 * Creating a plugin localization file.

--- a/src/main/java/sawfowl/localeapi/api/WatchLocales.java
+++ b/src/main/java/sawfowl/localeapi/api/WatchLocales.java
@@ -3,6 +3,7 @@ package sawfowl.localeapi.api;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
@@ -12,48 +13,50 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import sawfowl.localeapi.LocaleAPIMain;
+import org.apache.logging.log4j.Logger;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 
 class WatchLocales {
 
-	LocaleAPIMain plugin;
-	public WatchLocales(LocaleAPIMain instance, LocaleAPI localeAPI) {
-		plugin = instance;
-		this.localeAPI = localeAPI;
+	private LocaleService localeService;
+	private Logger logger;
+	private Path configDirectory;
+	private WatchService watchService;
+	private Map<String, Long> updated;
+	public WatchLocales(LocaleService localeService, Logger logger, Path path) {
+		this.localeService = localeService;
+		this.logger = logger;
+		configDirectory = path;
 		updated = new HashMap<String, Long>();
 		try {
 			watchService = FileSystems.getDefault().newWatchService();
 		} catch (IOException e) {
-			plugin.getLogger().error(e.getLocalizedMessage());
+			logger.error(e.getLocalizedMessage());
 		};
 		checkAndClearUpdated();
 	}
 
-	private WatchService watchService;
-	private LocaleAPI localeAPI;
-	private Map<String, Long> updated;
-
 	void addPluginData(String pluginID) {
+		if(updated.containsKey(pluginID)) return;
 		try {
 			updated.put(pluginID, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
-			plugin.getConfigDir().resolve(pluginID).register(watchService, ENTRY_CREATE, ENTRY_MODIFY);
-			plugin.getLogger().info("[FileWatcher] Added tracking of localization files for plugin: " + pluginID);
+			configDirectory.resolve(pluginID).register(watchService, ENTRY_CREATE, ENTRY_MODIFY);
+			logger.info("[FileWatcher] Added tracking of localization files for plugin: " + pluginID);
 		} catch (IOException e) {
-			plugin.getLogger().error(e.getLocalizedMessage());
+			logger.error(e.getLocalizedMessage());
 		}
 	}
 
 	void startWatch() {
-		plugin.getLogger().info("[FileWatcher] File tracking has been launched.");
+		logger.info("[FileWatcher] File tracking has been launched.");
 		WatchKey key;
 		try {
 			Thread.sleep(5000);
 			while ((key = watchService.take()) != null) {
 			    for (WatchEvent<?> event : key.pollEvents()) {
-		    		String pluginID = getPluginID(key.watchable().toString());
+		    		String pluginID = key.watchable().toString().replace(configDirectory.toString() + File.separator, "");
 		    		String fileName = event.context().toString();
 			    	if(event.kind() == ENTRY_CREATE) {
 			    		checkOnCreate(pluginID, fileName);
@@ -66,34 +69,30 @@ class WatchLocales {
 			    }
 			}
 		} catch (InterruptedException e) {
-			plugin.getLogger().error(e.getLocalizedMessage());
+			logger.error(e.getLocalizedMessage());
 		}
 	}
 
 	private void checkOnCreate(String pluginID, String fileName) {
 		long oldTime = System.currentTimeMillis();
-		for(Locale locale : localeAPI.getLocalesList()) {
+		for(Locale locale : localeService.getLocalesList()) {
 			if(fileName.contains(locale.toLanguageTag())) {
 				if(fileName.contains("tmp")) {
 					return;
 				}
-				if(updated.containsKey(pluginID) && updated.get(pluginID) + 5 > oldTime) return;
-				if(fileName.contains("conf")) {
-					plugin.getLogger().info("[FileWatcher] New locale file found -> " + fileName + "! Loading...");
-					localeAPI.createPluginLocale(pluginID, ConfigTypes.HOCON, locale);
-					plugin.getLogger().info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
-				} else if(fileName.contains("yml")) {
-					plugin.getLogger().info("[FileWatcher] New locale file found -> " + fileName + "! Loading...");
-					localeAPI.createPluginLocale(pluginID, ConfigTypes.YAML, locale);
-					plugin.getLogger().info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
-				} else if(fileName.contains("json")) {
-					plugin.getLogger().info("[FileWatcher] New locale file found -> " + fileName + "! Loading...");
-					localeAPI.createPluginLocale(pluginID, ConfigTypes.JSON, locale);
-					plugin.getLogger().info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
-				} else if(fileName.contains("properties")) {
-					plugin.getLogger().info("[FileWatcher] New locale file found -> " + fileName + "! Loading...");
-					localeAPI.createPluginLocale(pluginID, ConfigTypes.PROPERTIES, locale);
-					plugin.getLogger().info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
+				if((updated.containsKey(pluginID) && updated.get(pluginID) + 5 > oldTime) || localeService.getPluginLocales(pluginID).containsKey(locale)) return;
+				for(ConfigTypes configType : ConfigTypes.values()) {
+					String configTypeName = configType.toString();
+					if(fileName.contains(configTypeName)) {
+						int localesSizeBefore = localeService.getPluginLocales(pluginID).size();
+						logger.info("[FileWatcher] New locale file found -> " + fileName + " for plugin \"" + pluginID + "\"! Loading...");
+						localeService.createPluginLocale(pluginID, configType, locale);
+						if(localesSizeBefore < localeService.getPluginLocales(pluginID).size()) {
+							logger.info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
+						} else {
+							logger.error("[FileWatcher] Error loading file " + fileName + " for plugin \"" + pluginID + "\"!");
+						}
+					}
 				}
 				updated.put(pluginID + locale.toLanguageTag(), TimeUnit.MILLISECONDS.toSeconds(oldTime));
 				break;
@@ -103,22 +102,17 @@ class WatchLocales {
 
 	private void checkOnModify(String pluginID, String fileName) {
 		long oldTime = System.currentTimeMillis();
-		for(Locale locale : localeAPI.getLocalesList()) {
+		for(Locale locale : localeService.getLocalesList()) {
 			if(updated.containsKey(pluginID + locale.toLanguageTag())) return;
 			if(fileName.contains(locale.toLanguageTag()) && (fileName.contains("conf") || fileName.contains("yml") || fileName.equals("json") || fileName.contains("properties")) ) {
 				if(updated.containsKey(fileName)) 
-				plugin.getLogger().info("[FileWatcher] Locale file " + fileName + " has been changed! Reloading...");
-				localeAPI.getOrDefaultLocale(pluginID, locale).reload();
-				plugin.getLogger().info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
+				logger.info("[FileWatcher] Locale file " + fileName + " has been changed! Reloading...");
+				localeService.getOrDefaultLocale(pluginID, locale).reload();
+				//logger.info("[FileWatcher] Done. " + (System.currentTimeMillis() - oldTime) + "ms");
 				updated.put(pluginID + locale.toLanguageTag(), TimeUnit.MILLISECONDS.toSeconds(oldTime));
 				break;
 			}
 		}
-	}
-
-	private String getPluginID(String string) {
-		String result = string.split("localeapi" + File.separator)[1];
-		return result;
 	}
 
 	private void checkAndClearUpdated() {
@@ -136,7 +130,7 @@ class WatchLocales {
 						try {
 							Thread.sleep(10000);
 						} catch (InterruptedException e) {
-							plugin.getLogger().error(e.getLocalizedMessage());
+							logger.error(e.getLocalizedMessage());
 						}
 					}
 				}

--- a/src/main/java/sawfowl/localeapi/api/WatchThread.java
+++ b/src/main/java/sawfowl/localeapi/api/WatchThread.java
@@ -1,16 +1,15 @@
 package sawfowl.localeapi.api;
 
-import sawfowl.localeapi.LocaleAPIMain;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.Logger;
+
 
 public class WatchThread extends Thread {
 
-	LocaleAPIMain plugin;
-	LocaleAPI localeAPI;
 	private WatchLocales watchLocales;
-	public WatchThread(LocaleAPIMain instance, LocaleAPI localeAPI) {
-		plugin = instance;
-		this.localeAPI = localeAPI;
-		watchLocales = new WatchLocales(plugin, localeAPI);
+	public WatchThread(LocaleService localeService, Logger logger, Path path) {
+		watchLocales = new WatchLocales(localeService, logger, path);
 	}
 
 	public void run() {

--- a/src/main/java/sawfowl/localeapi/event/LocaleServiseEvent.java
+++ b/src/main/java/sawfowl/localeapi/event/LocaleServiseEvent.java
@@ -1,0 +1,27 @@
+package sawfowl.localeapi.event;
+
+import org.spongepowered.api.event.Event;
+
+import sawfowl.localeapi.api.LocaleService;
+
+public interface LocaleServiseEvent {
+
+	/**
+	 * This event is called during the `ConstructPluginEvent` event. </br>
+	 * Suitable for cases where LocaleAPI is mandatory.
+	 */
+	public interface Construct extends LocaleServiseEvent, Event{}
+
+	/**
+	 * This event is called during the `StartedEngineEvent<Server>` event. </br>
+	 * Suitable for cases where LocaleAPI is optional.
+	 */
+	public interface Started extends LocaleServiseEvent, Event{}
+
+	/**
+	 *  Getting API for localizations.
+	 * @return `LocaleService` interface
+	 */
+	public LocaleService getLocaleService();
+
+}

--- a/src/main/java/sawfowl/localeapi/utils/JsonLocaleUtil.java
+++ b/src/main/java/sawfowl/localeapi/utils/JsonLocaleUtil.java
@@ -5,42 +5,37 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import org.spongepowered.api.Sponge;
-import org.spongepowered.api.asset.Asset;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.util.locale.Locales;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.gson.GsonConfigurationLoader;
 import org.spongepowered.configurate.serialize.SerializationException;
-import org.spongepowered.plugin.PluginContainer;
-
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import sawfowl.localeapi.LocaleAPIMain;
+import sawfowl.localeapi.api.LocaleService;
 
 public class JsonLocaleUtil extends AbstractLocaleUtil {
 
-	private LocaleAPIMain plugin;
+	private LocaleService localeService;
+	private Logger logger;
 	private String pluginID;
-	private String locale;
 	private boolean thisIsDefault = false;
 	private GsonConfigurationLoader configLoader;
 	private ConfigurationNode localeNode;
 	private Path path;
 
-	public JsonLocaleUtil(LocaleAPIMain plugin, String pluginID, String locale) {
-		this.plugin = plugin;
+	public JsonLocaleUtil(LocaleService localeService, Logger logger, Path path, String pluginID, String locale) {
+		this.localeService = localeService;
+		this.logger = logger;
 		this.pluginID = pluginID;
-		this.locale = locale;
 		thisIsDefault = locale.equals(Locales.DEFAULT.toLanguageTag());
-		saveLocaleFile();
-		path = plugin.getConfigDir().resolve(pluginID + File.separator + locale + ".json");
-		configLoader = GsonConfigurationLoader.builder().defaultOptions(plugin.getConfigurationOptions()).path(path).build();
+		this.path = path.resolve(pluginID + File.separator + locale + ".json");
+		configLoader = GsonConfigurationLoader.builder().defaultOptions(localeService.getConfigurationOptions()).path(this.path).build();
 		reload();
 	}
 
@@ -49,7 +44,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 		try {
 			localeNode = configLoader.load();
 		} catch (IOException e) {
-			plugin.getLogger().error(e.getMessage());
+			logger.error(e.getMessage());
 		}
 	}
 
@@ -58,7 +53,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 		try {
 			configLoader.save(localeNode);
 		} catch (IOException e) {
-			plugin.getLogger().error(e.getMessage());
+			logger.error(e.getMessage());
 		}
 	}
 
@@ -98,7 +93,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 		try {
 			return getLocaleNode(path).virtual() && !thisIsDefault ? getDefaultLocale().getListStrings(path) : getLocaleNode(path).getList(String.class);
 		} catch (SerializationException e) {
-			plugin.getLogger().error(e.getLocalizedMessage());
+			logger.error(e.getLocalizedMessage());
 		}
 		return Arrays.asList("Error getting list of Strings " + getPathName(path));
 	}
@@ -114,7 +109,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 				}
 				return true;
 			} catch (SerializationException e) {
-				plugin.getLogger().error(e.getLocalizedMessage());
+				logger.error(e.getLocalizedMessage());
 			}
 		}
 		return false;
@@ -131,7 +126,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 				}
 				return true;
 			} catch (SerializationException e) {
-				plugin.getLogger().error(e.getLocalizedMessage());
+				logger.error(e.getLocalizedMessage());
 			}
 		}
 		return false;
@@ -144,7 +139,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 				getLocaleNode(path).set(string);
 				return true;
 			} catch (SerializationException e) {
-				plugin.getLogger().error(e.getLocalizedMessage());
+				logger.error(e.getLocalizedMessage());
 			}
 		}
 		return false;
@@ -157,7 +152,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 				getLocaleNode(path).setList(String.class, strings);
 				return true;
 			} catch (SerializationException e) {
-				plugin.getLogger().error(e.getLocalizedMessage());
+				logger.error(e.getLocalizedMessage());
 			}
 		}
 		return false;
@@ -180,7 +175,7 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 	}
 
 	private AbstractLocaleUtil getDefaultLocale() {
-		return plugin.getAPI().getPluginLocales(pluginID).get(Locales.DEFAULT);
+		return localeService.getPluginLocales(pluginID).get(Locales.DEFAULT);
 	}
 
 	private String getPathName(Object... path) {
@@ -195,27 +190,6 @@ public class JsonLocaleUtil extends AbstractLocaleUtil {
 			}
 		}
 		return name + "]";
-	}
-
-	private void saveLocaleFile() {
-		if(plugin.getConfigDir().resolve(pluginID + File.separator + locale + ".json").toFile().exists()) {
-			return;
-		}
-		Optional<PluginContainer> optPlugin = Sponge.pluginManager().plugin(pluginID);
-		if(optPlugin.isPresent()) {
-			Optional<Asset> assetOpt = Sponge.assetManager().asset(optPlugin.get(), "lang/" + locale + ".json");
-			if(assetOpt.isPresent()) {
-				Asset asset = assetOpt.get();
-				try {
-					if(!plugin.getConfigDir().resolve(pluginID + File.separator + locale + ".json").toFile().exists()) {
-						asset.copyToDirectory(plugin.getConfigDir().resolve(pluginID));
-						plugin.getLogger().info("Locale config saved");
-					}
-				} catch (IOException e) {
-					plugin. getLogger().error("Failed to save locale config! " + e.getLocalizedMessage());
-				}
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
Upgrade to the current version of SpongeAPI 8.
Changed the way to get API for localizations. Now events are used. The old way is marked as deprecated.
A slight simplification of saving assets.
Corrections to the file monitoring operation.
Cleaning the code from unnecessary methods.